### PR TITLE
Add opportunity to develop in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+
+FROM openjdk:8
+
+MAINTAINER tutinformatics
+
+# copy files to workdir
+ADD . /ofbiz
+
+WORKDIR /ofbiz
+
+RUN ./gradlew
+
+RUN ./gradlew cleanAll loadAll
+
+# Use volume mount for no restart xml changes etc.
+VOLUME /ofbiz
+
+# Run ofbiz
+ENTRYPOINT ./gradlew ofbiz

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.4'
+
+services:
+
+  ofbiz:
+    container_name: ofbiz
+    build:
+      context: .
+    restart: unless-stopped
+    ports:
+      - "8443:8443"
+      - "4567:4567"  # sparkle for REST api
+    volumes:
+      - ./:/ofbiz  # Volume mount to allow runtime changes to xml etc.

--- a/docs/how-to-develop-docker.md
+++ b/docs/how-to-develop-docker.md
@@ -1,0 +1,31 @@
+# Basic tutorial how to develop Ofbiz in docker
+
+## Prerequisites
+- Docker _(or Docker toolbox for Windows)_
+- Docker-compose 
+
+## Basic lifecycle
+**First launch:**
+```bash
+# You can use -d for detatched mode
+sudo docker-compose up
+```
+**If you don't need restart _(ftl templates, xml controller, etc)_:**  
+Simply edit files as they are mounted into docker so no restart is required! 
+   
+**For every update that needs recompiling java:**
+```bash
+# Stop the container (Can be acheived with Ctrl+C if dot detatched)
+sudo docker-compose stop ofbiz
+# Start it again
+sudo docker-compose up
+```
+**For every update that needs _"loadAll"_:**
+```bash
+# Stop container (Can be acheived with Ctrl+C if dot detatched)
+sudo docker-compose stop ofbiz
+# Remove all stopped containers and images
+sudo docker system prune -af
+# Start again
+sudo docker-compose up
+```


### PR DESCRIPTION
Mainly for the teams that have trouble running Ofbiz.

- Volume mounts whole repo into container, so no need to restart on every change

- Restart only rebuilds ofbiz, no `cleanAll`/ `loadAll`is ran for faster restarts

- You can rebuild image to run `./gradlew cleanAll loadAll` so you have new image with fresh data.

Guide can be found in: [docs](./docs/how-to-develop-docker.md)