### PR TITLE
Don't run ci/cd pipe on pull requests

### DIFF
--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -11,9 +11,6 @@
 name: Build and Deploy to GKE
 
 on:
-  pull_request:
-    branches: 
-      - trunk
   push:
     branches: 
       - manufacturing_warehouse_rest_plugin


### PR DESCRIPTION
Too many people blow up deploy atm.

Would make more sense to deploy only after merge anyways...